### PR TITLE
feat: #796 (Outreachy) Search by email should be using substrings

### DIFF
--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -155,9 +155,9 @@ class PushViewSet(viewsets.ViewSet):
         if author:
             if author.startswith("-"):
                 author = author[1::]
-                pushes = pushes.exclude(author=author)
+                pushes = pushes.exclude(author__iexact=author)
             else:
-                pushes = pushes.filter(author=author)
+                pushes = pushes.filter(author__iexact=author)
 
         if filter_params.get("hide_reviewbot_pushes") == "true":
             pushes = pushes.exclude(author="reviewbot")

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -159,6 +159,14 @@ class PushViewSet(viewsets.ViewSet):
             else:
                 pushes = pushes.filter(author__iexact=author)
 
+        author_contains = filter_params.get("author_contains")
+        if author_contains:
+            if author_contains.startswith("-"):
+                author_contains = author_contains[1::]
+                pushes = pushes.exclude(author__icontains=author_contains)
+            else:
+                pushes = pushes.filter(author__icontains=author_contains)
+
         if filter_params.get("hide_reviewbot_pushes") == "true":
             pushes = pushes.exclude(author="reviewbot")
 


### PR DESCRIPTION
This PR Fixes [#796](https://github.com/mozilla/perfcompare/issues/796)

It makes the existing author email search case insensitive and adds a new URL parameter (author_contains) that enables a substring search against the author's email. It uses Django's Field lookups `iexact` and `icontains` to achieve this. 

The changes can be tested by running any of the following cURL commands in a terminal (searching for this email as an example - chorotan@mozilla.com) : 

`curl "http://localhost:8000/api/project/autoland/push/?author_contains=ChoroTan"`
or 
`curl "http://localhost:8000/api/project/autoland/push/?author=Chorotan@mozilla.com"   `


The expected results should look like this both times:
```
{
   "meta":{
      "count":2,
      "repository":"autoland",
      "filter_params":{
         "author_contains":"ChoroTan"
      }
   },
   "results":[
      {
         "id":124,
         "revision":"77f5a2095426ee2ceaaabe3bf3698b3693a2e07b",
         "author":"chorotan@mozilla.com",
         "revisions":[
            {
               "result_set_id":124,
               "repository_id":77,
               "revision":"77f5a2095426ee2ceaaabe3bf3698b3693a2e07b",
               "author":"Cristina Horotan <chorotan@mozilla.com>",
               "comments":"Backed out changeset c6ce92301ca1 (bug 1791226) for causing assertion failures at nsBlockFrame.cpp on a CLOSED TREE"
            }
         ],
         "revision_count":1,
         "push_timestamp":1729302701,
         "repository_id":77
      },
      {
         "id":254,
         "revision":"e4fbc29742a20160104deadc26611ec507332d73",
         "author":"chorotan@mozilla.com",
         "revisions":[
            {
               "result_set_id":254,
               "repository_id":77,
               "revision":"e4fbc29742a20160104deadc26611ec507332d73",
               "author":"Cristina Horotan <chorotan@mozilla.com>",
               "comments":"Backed out 4 changesets (bug 1454816) for causing build bustages at nsIStringBundle.h CLOSED TREE\n\nBacked out changeset bed340babebd (bug 1454816)\nBacked out changeset f7499fb49eb0 (bug 1454816)\nBacked out changeset 9a82c5828c53 (bug 1454816)\nBacked out changeset efe7bc48a16d (bug 1454816)"
            }
         ],
         "revision_count":1,
         "push_timestamp":1729284184,
         "repository_id":77
      }
   ]
}
```

Which is the same results as you'd get when running this command before the changes made here -   `curl "http://localhost:8000/api/project/autoland/push/?author=chorotan@mozilla.com" `
  