### PR TITLE
#796 Search by email accepting substrings

### DIFF
--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -152,12 +152,16 @@ class PushViewSet(viewsets.ViewSet):
             pushes = pushes.filter(id__in=id_in_list)
 
         author = filter_params.get("author")
-        if author:
-            if author.startswith("-"):
-                author = author[1::]
-                pushes = pushes.exclude(author=author)
-            else:
-                pushes = pushes.filter(author=author)
+        author_contains = filter_params.get("author_contains")
+        if author_contains:
+            pushes = pushes.filter(author__icontains=author_contains)
+        else:
+            if author:
+               if author.startswith("-"):
+                   author = author[1::]
+                   pushes = pushes.exclude(author__iexact=author)
+               else:
+                  pushes = pushes.filter(author__iexact=author)
 
         if filter_params.get("hide_reviewbot_pushes") == "true":
             pushes = pushes.exclude(author="reviewbot")


### PR DESCRIPTION
## Description

 This PR improves the author search functionality by accepting substrings fixing this [issue](https://github.com/mozilla/perfcompare/issues/796)

## Before
- Searches only return results when the exact email address is entered
  - e.g `?author=yalmacki` would not return a result, but `?author=yalmacki@mozilla.com` would.

## After
The `author_contains` param was added to accept partial matches. `icontains` was used to ensure this. 
- e.g `?author_contains = yalmacki` , `?author_contains = yal`, `?author=yalmacki@mozilla.com` will all return a result.

https://github.com/user-attachments/assets/2410452b-fd73-42ed-a8a6-cdcae4ed5596

https://github.com/user-attachments/assets/4265e429-b803-4648-a0f3-94a6e1f2bddd

## Backward compatibility

I used `iexact`  to ensure that exact, case-insensitive matching still works for existing `author` params  e.g  `?author=yalmacki@mozilla.com`  will return a result


