### PR TITLE
Implement author filtering with case-insensitive and substring matching #796

### DIFF
--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -155,9 +155,17 @@ class PushViewSet(viewsets.ViewSet):
         if author:
             if author.startswith("-"):
                 author = author[1::]
-                pushes = pushes.exclude(author=author)
+                pushes = pushes.exclude(author__iexact=author)
             else:
-                pushes = pushes.filter(author=author)
+                pushes = pushes.filter(author__iexact=author)
+        
+        author_contains = filter_params.get("author_contains")
+        if author_contains:
+            if author_contains.startswith("-"):
+               author_contains = author_contains[1::]
+               pushes = pushes.exclude(author__icontains=author_contains)
+            else:
+               pushes = pushes.filter(author__icontains=author_contains)
 
         if filter_params.get("hide_reviewbot_pushes") == "true":
             pushes = pushes.exclude(author="reviewbot")

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -150,7 +150,8 @@ class PushViewSet(viewsets.ViewSet):
                     {"detail": "Invalid id__in specification"}, status=HTTP_400_BAD_REQUEST
                 )
             pushes = pushes.filter(id__in=id_in_list)
-
+        
+        filter_params = {key.lower(): value for key, value in request.GET.items()}
         author = filter_params.get("author")
         if author:
             if author.startswith("-"):
@@ -159,7 +160,7 @@ class PushViewSet(viewsets.ViewSet):
             else:
                 pushes = pushes.filter(author__iexact=author)
         
-        author_contains = filter_params.get("author_Contains")
+        author_contains = filter_params.get("author_contains")
         if author_contains:
             if author_contains.startswith("-"):
                author_contains = author_contains[1::]

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -159,7 +159,7 @@ class PushViewSet(viewsets.ViewSet):
             else:
                 pushes = pushes.filter(author__iexact=author)
         
-        author_contains = filter_params.get("author_contains")
+        author_contains = filter_params.get("author_Contains")
         if author_contains:
             if author_contains.startswith("-"):
                author_contains = author_contains[1::]


### PR DESCRIPTION
This PR Fixes https://github.com/mozilla/perfcompare/issues/796

This commit enhances the author filtering functionality in the pushes query by implementing the following changes:

1. Introduced a new parameter, author_contains, allowing for substring matching in email addresses, providing more flexible search capabilities.
2. The existing author parameter has been updated to use case-insensitive exact matches using iexact for improved accuracy.

Before: Without complete email address with parameter "author".

![Screenshot (750)](https://github.com/user-attachments/assets/2ce95f55-7762-44ad-aec4-91434b89c133)

After: Without complete email address with parameter "author_contains".

![Screenshot (752)](https://github.com/user-attachments/assets/6f62a6c3-501c-49da-bfa7-4f3d75c68887)

Complete Result;
[authorContains.pdf](https://github.com/user-attachments/files/17527861/authorContains.pdf)

